### PR TITLE
Return Http 404 in GET /papers when paper id not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-README.adoc
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,38 @@
+== API POC
+
+Test using a JWK endpoint instead of
+
+TLDR; Works! Start jwk-server, auth-server, create token and then create a user successfully.
+Modify kid in token in `JwtGenerator` and then try to crete a user, to see it fail with:
+
+```
+< HTTP/1.1 401 Unauthorized
+< WWW-Authenticate: Bearer error="invalid_token", error_description="Failed to validate the token", error_uri="https://tools.ietf.org/html/rfc6750#section-3.1"
+```
+
+== API USAGE
+
+
+=== Get Token
+
+[source,bash]
+----
+CLIENT_ID="189e2d22-2da5-44fb-ab0a-d5a57fac4d50"
+API_USERNAME="dadmin"
+API_PASSWORD="12345678asr"
+
+curl "http://localhost:8080/oauth/token?grant_type=password&client_id=$CLIENT_ID&username=$API_USERNAME&password=$API_PASSWORD" | jq
+----
+
+// TOKEN=$(curl -s "http://localhost:8080/oauth/token?grant_type=password&client_id=$CLIENT_ID&username=$API_USERNAME&password=$API_PASSWORD" | jq -r '.access_token')
+
+=== Create User
+
+curl -X POST 'http://localhost:8080/users' \
+-H "Authorization: Bearer $TOKEN" \
+-H 'Content-Type: application/json' \
+ -d '{
+"username":"my_nam2e222",
+"email": "mymail",
+"password":"12345678"
+ }' -v

--- a/src/main/java/org/bcnjug/jbcn/api/papers/PapersController.java
+++ b/src/main/java/org/bcnjug/jbcn/api/papers/PapersController.java
@@ -1,6 +1,7 @@
 package org.bcnjug.jbcn.api.papers;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -22,8 +23,10 @@ public class PapersController {
 
     @GetMapping(value = "/papers/{id}", produces = APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    Mono<Paper> getPaper(@PathVariable String id) {
-        return papersRepository.findById(id);
+    Mono<ResponseEntity<Paper>> getPaper(@PathVariable String id) {
+        return papersRepository.findById(id)
+                .map(paper -> ResponseEntity.ok(paper))
+                .switchIfEmpty(Mono.fromSupplier(() -> ResponseEntity.notFound().build()));
     }
 
     @PostMapping(value = "/papers", produces = APPLICATION_JSON_VALUE)


### PR DESCRIPTION
According to docs, annotated controllers should use ResponseEntity: https://docs.spring.io/spring-framework/docs/current/reference/html/web-reactive.html#webflux-ann-return-types.

Still tried ServerResponse and got serialization issues.